### PR TITLE
Set output directory predicate

### DIFF
--- a/sources/grail.pl
+++ b/sources/grail.pl
@@ -33,6 +33,7 @@ grail_help :-
 	format('~n',[]),
 	format('load_output_module(Name)               Use output_Name for output.~n',[]),
 	format('load_fragment(FileName)                Consult a grammar fragment.~n',[]),
+	format('set_output_module(Directory)           Write output files to given directory.~n',[]),
 	format('portray_examples                       Show example sentences of current fragment.~n',[]),
 	format('portray_lexicon                        Show words in current lexicon.~n',[]),
 	format('tokenize(String,ListOfWords)           Tokenize a string.~n',[]),
@@ -83,6 +84,19 @@ load_output_module(NameSuffix) :-
 	use_module(ModuleName),
 	retractall('active output module'(_)),
 	assert('active output module'(ModuleName)).
+
+
+% ---------------------------------------------------------------------
+% set_output_directory(+D)
+%
+% Write output files to directory D
+% ---------------------------------------------------------------------
+
+set_output_directory(Dir) :-
+	retractall('latex output directory'(_)),
+	atom_concat(Dir,'/',Dir2),
+	assert('latex output directory'(Dir2)).
+
 
 % ---------------------------------------------------------------------
 % generate_output(+ResultList)
@@ -176,6 +190,7 @@ tex_syn(ListOfSyn, Goal) :-
 	generate_output(Results).
        
 start :-
+	assert('latex output directory'('./')),
 	load_output_module(null),
 	format('~n~nWelcome to Grail!~nType \'grail_help.\' for toplevel predicates.~n~n',[]).
 

--- a/sources/grail.pl
+++ b/sources/grail.pl
@@ -33,7 +33,7 @@ grail_help :-
 	format('~n',[]),
 	format('load_output_module(Name)               Use output_Name for output.~n',[]),
 	format('load_fragment(FileName)                Consult a grammar fragment.~n',[]),
-	format('set_output_module(Directory)           Write output files to given directory.~n',[]),
+	format('set_output_directory(Directory)        Write output files to given directory.~n',[]),
 	format('portray_examples                       Show example sentences of current fragment.~n',[]),
 	format('portray_lexicon                        Show words in current lexicon.~n',[]),
 	format('tokenize(String,ListOfWords)           Tokenize a string.~n',[]),

--- a/sources/options.pl
+++ b/sources/options.pl
@@ -15,6 +15,7 @@
 :- module(options,
 		  [unary_semantics/1,
 		  latex_output_format/1,
+		  latex_output_file/1,
 		  eta_long_proofs/1,
 		  hypo_scope/1,
 		  ignore_brackets/1,
@@ -52,6 +53,14 @@ unary_semantics(inactive).
 % version does not support sequent output
 
 latex_output_format(nd).
+
+
+
+% latex_output_file(?Filename)
+% File to which the output modules will write tex output. The default name is
+% the one that is expected by the provided wrapper scripts.
+
+latex_output_file('somethingelse.tex').
 
 
 

--- a/sources/options.pl
+++ b/sources/options.pl
@@ -65,13 +65,6 @@ latex_output_file('proofs1.tex').
 
 
 
-% latex_output_directory(?Filename)
-% Directory to which to write the output files (eg<n>.tex and the above)
-
-latex_output_directory('./').
-
-
-
 
 % eta_long_proofs(?Flag)
 % Setting this flag to 'yes' will cause the eta reduction of the

--- a/sources/options.pl
+++ b/sources/options.pl
@@ -16,6 +16,7 @@
 		  [unary_semantics/1,
 		  latex_output_format/1,
 		  latex_output_file/1,
+		  latex_output_directory/1,
 		  eta_long_proofs/1,
 		  hypo_scope/1,
 		  ignore_brackets/1,
@@ -60,7 +61,15 @@ latex_output_format(nd).
 % File to which the output modules will write tex output. The default name is
 % the one that is expected by the provided wrapper scripts.
 
-latex_output_file('somethingelse.tex').
+latex_output_file('proofs1.tex').
+
+
+
+% latex_output_directory(?Filename)
+% Directory to which to write the output files (eg<n>.tex and the above)
+
+latex_output_directory('./').
+
 
 
 

--- a/sources/output_fitch_tex.pl
+++ b/sources/output_fitch_tex.pl
@@ -71,7 +71,7 @@ latex_output(CurrentSolutionIndex,Meaning,Proof,Con,Subst,NV) :-
 % NOTE: returns unexpected results when SolutionIndex > 9 !!
 % ---------------------------------------------------------------------
 texfile_name(FileName, SolutionIndex) :-
-	latex_output_directory(Dir),
+	'latex output directory'(Dir),
 	atom_codes(eg, EgCodes),
 	number_codes(SolutionIndex, IndexCodes),
 	append(EgCodes, IndexCodes, AtomCodes), atom_codes(ResultWithoutExtension, AtomCodes),
@@ -89,7 +89,7 @@ texfile_name(FileName, SolutionIndex) :-
 generate_latex_wrapper(NumberOfInputStatements) :-
 	telling(Stream),
 	latex_output_file(TexBase),
-	latex_output_directory(TexDir),
+	'latex output directory'(TexDir),
 	atom_concat(TexDir,TexBase,TexFile),
 	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),

--- a/sources/output_fitch_tex.pl
+++ b/sources/output_fitch_tex.pl
@@ -71,10 +71,12 @@ latex_output(CurrentSolutionIndex,Meaning,Proof,Con,Subst,NV) :-
 % NOTE: returns unexpected results when SolutionIndex > 9 !!
 % ---------------------------------------------------------------------
 texfile_name(FileName, SolutionIndex) :-
-	AsciiNumber is SolutionIndex + 48,
-	append("eg",[AsciiNumber],String1),
-	append(String1,".tex",String2),
-	name(FileName,String2).
+	latex_output_directory(Dir),
+	atom_codes(eg, EgCodes),
+	number_codes(SolutionIndex, IndexCodes),
+	append(EgCodes, IndexCodes, AtomCodes), atom_codes(ResultWithoutExtension, AtomCodes),
+	atom_concat(ResultWithoutExtension,'.tex',BaseName),
+	atom_concat(Dir,BaseName,FileName).
 
 
 
@@ -86,7 +88,9 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfInputStatements) :-
 	telling(Stream),
-	latex_output_file(TexFile),
+	latex_output_file(TexBase),
+	latex_output_directory(TexDir),
+	atom_concat(TexDir,TexBase,TexFile),
 	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),

--- a/sources/output_fitch_tex.pl
+++ b/sources/output_fitch_tex.pl
@@ -81,12 +81,13 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 % generate_latex_wrapper(+NumberOfInputStatements)
 %
-% Generates the file 'proofs1.tex' containing NumberOfInputStatements
+% Generates the file (default 'proofs1.tex') containing NumberOfInputStatements
 % \input statements for eg?.tex files.
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfInputStatements) :-
 	telling(Stream),
-	tell('proofs1.tex'),
+	latex_output_file(TexFile),
+	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),
 	format('\\usepackage{ifthen}~n',[]),

--- a/sources/output_prawitz_dep_tex.pl
+++ b/sources/output_prawitz_dep_tex.pl
@@ -77,12 +77,13 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 % generate_latex_wrapper(+NumberOfIncludeStatements)
 %
-% Generates the file 'proofs1.tex' containing NumberOfIncludeStatements
+% Generates the file (default 'proofs1.tex') containing NumberOfIncludeStatements
 % \input statements for eg?.tex files.
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfIncludeStatements) :-
 	telling(Stream),
-	tell('proofs1.tex'),
+	latex_output_file(TexFile),
+	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),
 	format('\\usepackage{ifthen}~n',[]),

--- a/sources/output_prawitz_dep_tex.pl
+++ b/sources/output_prawitz_dep_tex.pl
@@ -67,12 +67,12 @@ latex_output(CurrentSolutionIndex,Meaning,Proof,Con,Subst,NV) :-
 % NOTE: returns unexpected results when SolutionIndex > 9 !!
 % ---------------------------------------------------------------------
 texfile_name(FileName, SolutionIndex) :-
+	'latex output directory'(Dir),
 	atom_codes(eg, EgCodes),
 	number_codes(SolutionIndex, IndexCodes),
 	append(EgCodes, IndexCodes, AtomCodes), atom_codes(ResultWithoutExtension, AtomCodes),
-	atom_concat(ResultWithoutExtension,'.tex',FileName).
-
-
+	atom_concat(ResultWithoutExtension,'.tex',BaseName),
+	atom_concat(Dir,BaseName,FileName).
 
 % ---------------------------------------------------------------------
 % generate_latex_wrapper(+NumberOfIncludeStatements)
@@ -82,7 +82,9 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfIncludeStatements) :-
 	telling(Stream),
-	latex_output_file(TexFile),
+	latex_output_file(TexBase),
+	'latex output directory'(TexDir),
+	atom_concat(TexDir,TexBase,TexFile),
 	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),

--- a/sources/output_prawitz_tex.pl
+++ b/sources/output_prawitz_tex.pl
@@ -97,12 +97,13 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 % generate_latex_wrapper(+NumberOfIncludeStatements)
 %
-% Generates the file 'proofs1.tex' containing NumberOfIncludeStatements
+% Generates the file (default 'proofs1.tex') containing NumberOfIncludeStatements
 % \input statements for eg?.tex files.
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfIncludeStatements) :-
 	telling(Stream),
-	tell('proofs1.tex'),
+	latex_output_file(TexFile),
+	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),
 	format('\\usepackage{ifthen}~n',[]),

--- a/sources/output_prawitz_tex.pl
+++ b/sources/output_prawitz_tex.pl
@@ -87,10 +87,12 @@ latex_output(CurrentSolutionIndex,Meaning,Proof,Con,Subst,NV) :-
 % NOTE: returns unexpected results when SolutionIndex > 9 !!
 % ---------------------------------------------------------------------
 texfile_name(FileName, SolutionIndex) :-
+	latex_output_directory(Dir),
 	atom_codes(eg, EgCodes),
 	number_codes(SolutionIndex, IndexCodes),
 	append(EgCodes, IndexCodes, AtomCodes), atom_codes(ResultWithoutExtension, AtomCodes),
-	atom_concat(ResultWithoutExtension,'.tex',FileName).
+	atom_concat(ResultWithoutExtension,'.tex',BaseName),
+	atom_concat(Dir,BaseName,FileName).
 
 
 
@@ -102,7 +104,9 @@ texfile_name(FileName, SolutionIndex) :-
 % ---------------------------------------------------------------------
 generate_latex_wrapper(NumberOfIncludeStatements) :-
 	telling(Stream),
-	latex_output_file(TexFile),
+	latex_output_file(TexBase),
+	latex_output_directory(TexDir),
+	atom_concat(TexDir,TexBase,TexFile),
 	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),
 	format('\\usepackage{calc}~n',[]),

--- a/sources/output_prawitz_tex.pl
+++ b/sources/output_prawitz_tex.pl
@@ -87,7 +87,7 @@ latex_output(CurrentSolutionIndex,Meaning,Proof,Con,Subst,NV) :-
 % NOTE: returns unexpected results when SolutionIndex > 9 !!
 % ---------------------------------------------------------------------
 texfile_name(FileName, SolutionIndex) :-
-	latex_output_directory(Dir),
+	'latex output directory'(Dir),
 	atom_codes(eg, EgCodes),
 	number_codes(SolutionIndex, IndexCodes),
 	append(EgCodes, IndexCodes, AtomCodes), atom_codes(ResultWithoutExtension, AtomCodes),
@@ -105,7 +105,7 @@ texfile_name(FileName, SolutionIndex) :-
 generate_latex_wrapper(NumberOfIncludeStatements) :-
 	telling(Stream),
 	latex_output_file(TexBase),
-	latex_output_directory(TexDir),
+	'latex output directory'(TexDir),
 	atom_concat(TexDir,TexBase,TexFile),
 	tell(TexFile),
 	format('\\documentclass[11pt]{article}~n',[]),


### PR DESCRIPTION
This feature allows the user to manipulate the output directory, for example, to collect egN.tex and proofs1.tex of parallel runs.
